### PR TITLE
Make PDF figure outputs deterministic, and make PDF text editable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 * Two new functions to customize tick labels on any existing plot:
     * `wrap_tick_labels`: add text wrapping
     * `add_sample_size_to_labels`: add group sample sizes with a `(n=N)` suffix
-
-
+* Make writing PDF figures a deterministic process and make the PDF text editable.
 
 ## 0.5.0 (2022-01-10)
 

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ build-docker-test-image: requirements_dev.txt
 
 ## run tests locally using the docker image that matches Github Actions platform
 test: build-docker-test-image
-	docker run --rm -it -v $$(pwd):/src genetools-test pytest --cov=./ --cov-report term --cov-report xml --mpl --mpl-results-path=tests/results -vv;
+	docker run --rm -it -v $$(pwd):/src genetools-test pytest --cov=./ --cov-report term --cov-report xml --mpl --mpl-results-path=tests/results --basetemp=tests/results -vv;
 
 # run tests locally, without docker, therefore omitting the snapshot tests
 test-without-figures:


### PR DESCRIPTION
Previously I'd rerun the same code and get a different PDF file. Turns out a "created date" header was changing. This PR sets the created date to a fixed value, so your PDF only changes when the plot actually changes.

This also activates a PDF font-type that is editable in vector graphics tools like Illustrator.