### PR TITLE
Relative density

### DIFF
--- a/genetools/plots.py
+++ b/genetools/plots.py
@@ -376,6 +376,8 @@ def two_class_relative_density_plot(
 ):
     """[summary]
 
+    For alternatives, see contour KDEs in seaborn's displot function.
+
     :param data: [description]
     :type data: [type]
     :param x_key: [description]

--- a/genetools/plots.py
+++ b/genetools/plots.py
@@ -412,7 +412,7 @@ def two_class_relative_density_plot(
 
     # choose bins to remove: drop bins with low number of counts
     # i.e. low overall density
-    bins_to_remove = bin_sizes[bin_sizes < bin_sizes.quantile(0.25)].reset_index(
+    bins_to_remove = bin_sizes[bin_sizes < bin_sizes.quantile(quantile)].reset_index(
         name="size"
     )
 


### PR DESCRIPTION
To consider for 2D density (not relative between classes), instead of `sns.jointplot`:

```python
# set minimum count for background cells: https://stackoverflow.com/a/5405654/130164
# also set grid size
ax.hexbin(x_values, y_values, mincnt=10, gridsize=25, cmap="Blues")


# see https://stackoverflow.com/a/64105308/130164 for other alternatives:
# plt.hist2d(
#     x_values,
#     y_values,
#     bins=100,
# )

# see also https://stackoverflow.com/a/47404042/130164?
```